### PR TITLE
[Feature] - Implement Drag-and-Drop Upload and Enhanced Disable Logic for Editor

### DIFF
--- a/src/hooks/useTextManagement.ts
+++ b/src/hooks/useTextManagement.ts
@@ -5,18 +5,7 @@ export const useTextManagement = (stageSize: {
   width: number;
   height: number;
 }) => {
-  const [texts, setTexts] = useState<TextProperties[]>([
-    {
-      id: "text-1",
-      text: "Your Text Here",
-      x: 100,
-      y: 100,
-      fontSize: 24,
-      fontFamily: "Arial",
-      fill: "#000000",
-      opacity: 1,
-    },
-  ]);
+  const [texts, setTexts] = useState<TextProperties[]>([]);
   const [selectedTextId, setSelectedTextId] = useState<string | null>(null);
 
   const addText = () => {


### PR DESCRIPTION
## **PR:** Implement Drag-and-Drop Upload and Enhanced Disable Logic 

**Description:**

This PR enhances the image editor by replacing the file input with a drag-and-drop interface on the canvas and updates the disable logic for the "Add Text" and "Save Image" buttons. The focus is on improving user interaction with a modern upload method and enforcing a workflow where text addition and saving are disabled until specific conditions are met, specifically tied to the background-removed image (`bgRemovedImg`).

### Changes Made:

1. **Drag-and-Drop Implementation**:
   - Removed the sidebar file input and added drag-and-drop support to the canvas area.
   - Added event handlers:
     - `handleDragOver`: Shows a dashed border and tinted background.
     - `handleDragLeave`: Resets the UI.
     - `handleDrop`: Processes dropped files via `handleImageUpload`.
   - Implemented `handleCanvasClick` to trigger file selection on click when no image is present.
   - Enhanced UI:
     - Animated text ("Drop your image here!" during drag, "Drag & drop or click..." otherwise).
     - Larger upload icon and supported formats hint.
     - Loading overlay with spinner and "Processing your image..." text.

2. **Disable Logic for "Add Text" Button**:
   - Updated `disabled={!bgRemovedImg}`:
     - Button is disabled until `bgRemovedImg` exists, preventing text addition before background removal.
   - Styling:
     - Enabled: `bg-gradient-to-r from-brand-500 to-brand-700` with hover effects when `bgRemovedImg` is truthy.
     - Disabled: `bg-gray-400 cursor-not-allowed` when `bgRemovedImg` is falsy.

3. **Disable Logic for "Save Image" Button**:
   - Updated `hasContent = bgRemovedImg && texts.length > 0`:
     - Button is disabled unless both `bgRemovedImg` exists and at least one text element is added.
   - Updated `disabled={!hasContent}` to reflect the new `hasContent` definition.
   - Styling:
     - Enabled: `bg-gradient-to-r from-brand-700 to-brand-900` with hover effects when `hasContent` is true.
     - Disabled: `bg-gray-400 cursor-not-allowed` when `hasContent` is false.

4. **TypeScript Fix for `handleCanvasClick`**:
   - Corrected type mismatch in `input.onchange` by asserting `Event` as `React.ChangeEvent<HTMLInputElement>` for compatibility with `handleImageUpload`.

5. **No Initial Text**:
   - Ensured no text renders on load by relying on `useTextManagement` to start with an empty `texts` array.

### Why These Changes?
- **Drag-and-Drop**: Replaces a clunky file input with a modern, intuitive upload method, improving usability with clear visual feedback.
- **Disable Logic**: Enforces a workflow where text and saving are only available after background removal, ensuring users complete key steps before proceeding.
- **User Experience**: Combines functional restrictions with UI polish to guide users effectively.

### Testing Steps:
1. **Drag-and-Drop**:
   - Drag an image over the canvas; verify dashed border and "Drop your image here!" appear.
   - Drop the image; ensure it uploads and shows the loading overlay.
2. **Canvas Click**:
   - Click the canvas with no image; confirm file picker opens and uploads work.
3. **Button Disable Logic**:
   - Initial load: Both buttons should be disabled (gray).
   - After upload, before `bgRemovedImg`: "Add Text" and "Save Image" remain disabled.
   - After `bgRemovedImg` appears: "Add Text" enables, "Save Image" stays disabled.
   - After adding text: Both buttons enable with active styling.
4. **Save**:
   - Save with `bgRemovedImg` and text; verify output is correct.

### Screenshots:
- Before: Sidebar file input, buttons always enabled.
![Screenshot 2025-03-30 at 10 07 09 PM](https://github.com/user-attachments/assets/0bc8ea4c-547f-47a7-80b2-d6339028a6de)
- After: Drag-and-drop canvas, buttons disabled until `bgRemovedImg` and text conditions are met.
![Screenshot 2025-03-30 at 10 08 43 PM](https://github.com/user-attachments/assets/7829c73c-d3e6-4d94-bb89-389631b3b09c)

### Notes:
- Assumes background removal is required. If users should work with `originalImg` alone, adjust conditions to use `originalImg` instead of `bgRemovedImg`.
- `handleSave` uses `origDims`; update to `bgDims` if saving should reflect `bgRemovedImg`.
---